### PR TITLE
Add Firefox extension output to build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-browser*
+chrome*
+firefox*
 dist*

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,13 @@
 all: st hp sp
 
 st:
-	BRAND=MST LABEL=ST SUFFIX="-st" ./build.sh
+	BROWSER=chrome BRAND=MST LABEL=ST SUFFIX="-st" ./build.sh
+	BROWSER=firefox  BRAND=MST LABEL=ST SUFFIX="-st" ./build.sh
 
 hp:
-	BRAND=HivePoint LABEL=HP SUFFIX="-hp" ./build.sh
+	BROWSER=chrome BRAND=HivePoint LABEL=HP SUFFIX="-hp" ./build.sh
+	BROWSER=firefox BRAND=HivePoint LABEL=HP SUFFIX="-hp" ./build.sh
 
 sp:
-	BRAND=Spirent LABEL=SP SUFFIX="-sp" ./build.sh
-
+	BROWSER=chrome BRAND=Spirent LABEL=SP SUFFIX="-sp" ./build.sh
+	BROWSER=firefox BRAND=Spirent LABEL=SP SUFFIX="-sp" ./build.sh

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,10 @@
 #!/bin/sh -x
 
-VER=2024.3.1
+#VER=2024.4.1
+
+VER=$(curl --silent "https://api.github.com/repos/bitwarden/clients/releases" |	# get latest browser release version number
+	grep -m 1 '"tag_name": "browser-v' |
+	sed -E 's/.*"browser-v([^"]+)".*/\1/')
 
 echo "Building for '$BRAND' with suffix '$SUFFIX' and watermark '$LABEL'"
 

--- a/build.sh
+++ b/build.sh
@@ -6,17 +6,17 @@ VER=$(curl --silent "https://api.github.com/repos/bitwarden/clients/releases" |	
 	grep -m 1 '"tag_name": "browser-v' |
 	sed -E 's/.*"browser-v([^"]+)".*/\1/')
 
-echo "Building for '$BRAND' with suffix '$SUFFIX' and watermark '$LABEL'"
+echo "Building '$BROWSER' extension for '$BRAND' with suffix '$SUFFIX' and watermark '$LABEL', BitWarden release ${VER}"
 
-wget -N https://github.com/bitwarden/browser/releases/download/browser-v${VER}/dist-chrome-${VER}.zip
-rm -rf browser${SUFFIX}
-unzip -qd browser${SUFFIX} dist-chrome-${VER}.zip
-(cd browser${SUFFIX} && find . -type f -exec perl -pi -e 's/"Bitwarden"/"Bitwarden - '${BRAND}'"/go;' {} \;)
-(cd browser${SUFFIX} && find . -type f -exec perl -pi -e 's/"Bitwarden - Free Password Manager"/"Bitwarden - '${BRAND}'"/go;' {} \;)
-(cd browser${SUFFIX} && find . -type f -exec perl -pi -e 's{<title>Bitwarden</title>}{<title>Bitwarden - '${BRAND}'</title>}go;' {} \;)
+wget -N https://github.com/bitwarden/clients/releases/download/browser-v${VER}/dist-${BROWSER}-${VER}.zip
+rm -rf ${BROWSER}${SUFFIX}
+unzip -qd ${BROWSER}${SUFFIX} dist-${BROWSER}-${VER}.zip
+(cd ${BROWSER}${SUFFIX} && find . -type f -exec perl -pi -e 's/"Bitwarden"/"Bitwarden - '${BRAND}'"/go;' {} \;)
+(cd ${BROWSER}${SUFFIX} && find . -type f -exec perl -pi -e 's/"Bitwarden - Free Password Manager"/"Bitwarden - '${BRAND}'"/go;' {} \;)
+(cd ${BROWSER}${SUFFIX} && find . -type f -exec perl -pi -e 's{<title>Bitwarden</title>}{<title>Bitwarden - '${BRAND}'</title>}go;' {} \;)
 rm -rf newimages
 mkdir -p newimages
-for file in browser${SUFFIX}/images/*; do
+for file in ${BROWSER}${SUFFIX}/images/*; do
 	case $file in
 		*128)
 			pointsize="-pointsize 24"
@@ -34,5 +34,19 @@ for file in browser${SUFFIX}/images/*; do
 			
 	composite $pointsize label:"${LABEL}" -gravity NorthWest $file newimages/`basename $file`
 done
-cp newimages/* browser${SUFFIX}/images/
+cp newimages/* ${BROWSER}${SUFFIX}/images/
 rm -rf newimages
+
+if [ "$BROWSER" = "firefox" ]; then
+	# Firefox extensions require a unique ID in manifest.json at applications.gecko.id
+	suffix_slug=`echo "$LABEL" | iconv -t ascii//TRANSLIT | sed -r s/[^a-zA-Z0-9]+/-/g | sed -r s/^-+\|-+$//g | tr A-Z a-z`
+	sed -i "s/\"id\": \"{.*}\"/\"id\": \"$suffix_slug@mst\.edu\""/ ${BROWSER}${SUFFIX}/manifest.json
+	
+	# Firefox extensions must be packaged as .xpi files
+	rm bitwarden-${BROWSER}${SUFFIX}.xpi
+	(cd ${BROWSER}${SUFFIX}; zip -r --compression-method store ../bitwarden-${BROWSER}${SUFFIX}.zip ./)
+	mv bitwarden-${BROWSER}${SUFFIX}.zip bitwarden-${BROWSER}${SUFFIX}.xpi
+	rm -rf ${BROWSER}${SUFFIX}
+
+	# Note this extension will be unsigned. Toggle xpinstall.signatures.required in about:config under Developer Edition, Nightly, or ESR to allow install
+fi


### PR DESCRIPTION
Adds the creation of Firefox .xpi extensions to the build process, installable in ESR, Developer Edition, or Nightly with about:config > xpinstall.signatures.required set to false.

Potential unwanted change of output folders for Chrome from "browser-hp" etc. to "chrome-hp" to differentiate browser extension's source they were created from.

Does add dependencies to curl and zip, which may not be in some base installs.

Updates URLs to the bitwarden/clients repo to avoid 302 redirects.

Adds an automatic check for the latest release of bitwarden/clients/browser before building.